### PR TITLE
Fix for CTRL + click

### DIFF
--- a/jquery-bigTarget.js
+++ b/jquery-bigTarget.js
@@ -62,11 +62,14 @@
 						.hover(function() {
 							$clickZone.toggleClass(o['clickZoneHoverClass']);
 						})
-						.click(function() {
-							if(getSelectedText() == "") {
-								($a.is('[rel*=external]') && o["openRelExternalInNewWindow"]) 
-									? window.open(href) 
-									: window.location = href;
+						.click(function(e) {
+							if ( ! e.ctrlKey)
+							{
+								if(getSelectedText() == "") {
+									($a.is('[rel*=external]') && o["openRelExternalInNewWindow"]) 
+										? window.open(href) 
+										: window.location = href;
+								}
 							}
 						});
 				});


### PR DESCRIPTION
Prevent opening link if you CTRL + click on inner href. It just have to open new tab with link, not open in same tab too.
