### PR TITLE
Fix for CMD + click on MAC

### DIFF
--- a/jquery-bigTarget.js
+++ b/jquery-bigTarget.js
@@ -63,7 +63,7 @@
 							$clickZone.toggleClass(o['clickZoneHoverClass']);
 						})
 						.click(function(e) {
-							if ( ! e.ctrlKey)
+							if ( ! (e.metaKey || e.ctrlKey))
 							{
 								if(getSelectedText() == "") {
 									($a.is('[rel*=external]') && o["openRelExternalInNewWindow"]) 


### PR DESCRIPTION
Prevent opening link if you CMD + click on inner href on MAC.
